### PR TITLE
Ensure no headers set when path does not match

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ let metrics;
 let readinessChecks = [];
 let healthChecks = [];
 
+const prometheusContentType = 'text/plain; version=0.0.4';
+
 const doCheck = ({ name, check }) =>
   new Promise((resolve) => {
     // Pass in the [ok, warning, critical, unknown] callbacks. i.e. just resolve the promise.
@@ -29,9 +31,9 @@ const addReadinessCheck = (check) => readinessChecks.push(check);
 const addMetrics = (m) => { metrics = m; };
 
 const getMiddleware = () => (req, res, next) => {
-  res.header('Content-Type', 'text/plain; version=0.0.4');
-
   if (req.path === '/healthz') {
+    res.set('Content-Type', prometheusContentType);
+
     if (readinessChecks.length < 1) {
       return Promise.resolve().then(() => res.sendStatus(200));
     }
@@ -49,6 +51,8 @@ const getMiddleware = () => (req, res, next) => {
 
   // Run the checks and return in prometheus formats
   else if (req.path === '/checkz') {
+    res.set('Content-Type', prometheusContentType);
+
     if (healthChecks.length < 1) {
       return Promise.resolve().then(() => res.sendStatus(404));
     }
@@ -69,6 +73,8 @@ const getMiddleware = () => (req, res, next) => {
 
   // Send any prometheus metrics specified
   else if (req.path === '/metricz') {
+    res.set('Content-Type', prometheusContentType);
+
     if (!metrics) {
       return Promise.resolve().then(() => res.sendStatus(404));
     }

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ describe('bw-monitoring', () => {
   beforeEach(() => {
     req = {};
     res = {
-      header: () => {},
+      set: sinon.spy(),
       sendStatus: sinon.spy(),
       send: sinon.spy(),
     };
@@ -26,7 +26,7 @@ describe('bw-monitoring', () => {
     req.path = '/your-app';
     const mid = mon.getMiddleware();
     mid(req, res, next);
-    assert(next.called, true);
+    assert(next.called);
   });
 
   describe('/healthz endpoint', () => {
@@ -38,7 +38,7 @@ describe('bw-monitoring', () => {
       const mid = mon.getMiddleware();
       mid(req, res, next)
         .then(() => {
-          assert(res.sendStatus.calledWith(200), true);
+          assert(res.sendStatus.calledWith(200));
           done();
         });
     });
@@ -49,7 +49,7 @@ describe('bw-monitoring', () => {
       const mid = mon.getMiddleware();
       mid(req, res, next)
         .then(() => {
-          assert(res.sendStatus.calledWith(200), true);
+          assert(res.sendStatus.calledWith(200));
           done();
         });
     });
@@ -62,7 +62,7 @@ describe('bw-monitoring', () => {
       const mid = mon.getMiddleware();
       mid(req, res, next)
         .then(() => {
-          assert(res.sendStatus.calledWith(500), true);
+          assert(res.sendStatus.calledWith(500));
           done();
         });
     });
@@ -77,7 +77,7 @@ describe('bw-monitoring', () => {
       const mid = mon.getMiddleware();
       mid(req, res, next)
         .then(() => {
-          assert(res.sendStatus.calledWith(404), true);
+          assert(res.sendStatus.calledWith(404));
           done();
         });
     });
@@ -88,7 +88,7 @@ describe('bw-monitoring', () => {
       const mid = mon.getMiddleware();
       mid(req, res, next)
         .then(() => {
-          assert(res.send.calledWith('bob0 0\nbob1 0\n'), true);
+          assert(res.send.calledWith('bob0 0\nbob1 0\n'));
           done();
         });
     });
@@ -101,7 +101,7 @@ describe('bw-monitoring', () => {
       const mid = mon.getMiddleware();
       mid(req, res, next)
         .then(() => {
-          assert(res.send.calledWith('bob0 0\nbob1 1\nbob2 2\nbob3 3\n'), true);
+          assert(res.send.calledWith('bob0 0\nbob1 1\nbob2 2\nbob3 3\n'));
           done();
         });
     });
@@ -116,7 +116,7 @@ describe('bw-monitoring', () => {
       const mid = mon.getMiddleware();
       mid(req, res, next)
         .then(() => {
-          assert(res.sendStatus.calledWith(404), true);
+          assert(res.sendStatus.calledWith(404));
           done();
         });
     });
@@ -126,9 +126,39 @@ describe('bw-monitoring', () => {
       const mid = mon.getMiddleware();
       mid(req, res, next)
         .then(() => {
-          assert(res.send.calledWith('some string basically'), true);
+          assert(res.send.calledWith('some string basically'));
           done();
         });
+    });
+  });
+
+  describe('Content-Type header', () => {
+    it('is not set if no paths match', () => {
+      req.path = '/nothing-interesting';
+      const mid = mon.getMiddleware();
+      mid(req, res, next);
+      assert.equal(res.set.callCount, 0);
+    });
+
+    it('is set for /metricz', () => {
+      req.path = '/metricz';
+      const mid = mon.getMiddleware();
+      mid(req, res, next);
+      assert.equal(res.set.callCount, 1);
+    });
+
+    it('is set for /checkz', () => {
+      req.path = '/checkz';
+      const mid = mon.getMiddleware();
+      mid(req, res, next);
+      assert.equal(res.set.callCount, 1);
+    });
+
+    it('is set for /healthz', () => {
+      req.path = '/healthz';
+      const mid = mon.getMiddleware();
+      mid(req, res, next);
+      assert.equal(res.set.callCount, 1);
     });
   });
 });


### PR DESCRIPTION
* Remove depreacted 'headers' function in favour of 'set'.
* Add tests for setting Content-Type.
* Fix incorrect use of assert().