### PR TITLE
Don't allow public IPs to request monitoring endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -748,6 +748,11 @@
         }
       }
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "eslint-plugin-import": "^2.16.0",
     "mocha": "^5.2.0",
     "sinon": "^6.3.5"
+  },
+  "dependencies": {
+    "ip": "^1.1.5"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /**
  * Configure a ExpressJS middleware to expose useful health/metrics/checks endpoints.
  */
+const ip = require('ip');
 
 // Default empty configuration
 let metrics;
@@ -30,6 +31,12 @@ const addReadinessCheck = (check) => readinessChecks.push(check);
 const addMetrics = (m) => { metrics = m; };
 
 const getMiddleware = () => (req, res, next) => {
+  const requestingIP = req.ip || req.connection.remoteAddress
+                       || req.socket.remoteAddress || req.connection.socket.remoteAddress;
+  if (!ip.isPrivate(requestingIP)) {
+    return next();
+  }
+
   if (req.path === '/healthz') {
     res.set('Content-Type', prometheusContentType);
 

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,11 @@ describe('bw-monitoring', () => {
   let next;
 
   beforeEach(() => {
-    req = {};
+    req = {
+      connection: {
+        remoteAddress: '127.0.0.1'
+      }
+    };
     res = {
       set: sinon.spy(),
       sendStatus: sinon.spy(),
@@ -28,6 +32,19 @@ describe('bw-monitoring', () => {
     const mid = mon.getMiddleware();
     mid(req, res, next);
     assert(next.called);
+  });
+
+  describe('IP filtering', () => {
+    beforeEach(() => {
+      req.path = '/healthz';
+    });
+
+    it('Filters out non-private IPs', () => {
+      const mid = mon.getMiddleware();
+      req.connection.remoteAddress = '4.4.4.4';
+      mid(req, res, next);
+      assert(next.called);
+    });
   });
 
   describe('/healthz endpoint', () => {


### PR DESCRIPTION
This still allows through requests from 'private' IPs - 10.x, localhost etc