### PR TITLE
AFA-223. Allow metricz endpoint to accept function that yields promise

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ const getMiddleware = () => (req, res, next) => {
       return Promise.resolve().then(() => res.sendStatus(404));
     }
 
-    return Promise.resolve().then(() => res.send(metrics()));
+    return Promise.resolve(metrics()).then((actualMetrics) => res.send(actualMetrics));
   }
 
   return next();

--- a/test/index.js
+++ b/test/index.js
@@ -189,6 +189,15 @@ describe('bw-monitoring', () => {
           done();
         });
     });
+
+    it('should resolve a promise containing metrics', (done) => {
+      mon.addMetrics(async () => 'a string that was promised');
+      const mid = mon.getMiddleware();
+      mid(req, res, next).then(() => {
+        assert(res.send.calledWith('a string that was promised'));
+        done();
+      });
+    });
   });
 
   describe('Content-Type header', () => {


### PR DESCRIPTION
The prometheus client for node [is updating to return a promise from the `registry.metrics` function](https://github.com/siimon/prom-client/blob/master/CHANGELOG.md#1300---2020-12-16) that we tend to use with this endpoint. This change should maintain backwards compatibility as the non-promise version will just immediately resolve successfully.