### PR TITLE
AFA-223. Change name of package to place it in @brandwatch namespace.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bw-monitoring",
+  "name": "@brandwatch/monitoring",
   "version": "1.4.0",
   "description": "Add metric/checks endpoints to expressjs apps",
   "main": "src/index.js",


### PR DESCRIPTION
We currently don't have the ability to publish to the `bw-monitoring` package and aren't likely to be able to in the immediate future. We have a few other OS packages in the `@brandwatch` namespace so I believe that we can use that instead to allow us to publish new versions of the package.

I think we will need someone who has access to the Brandwatch npm account to set this up.

We'll need a further PR to update the readme etc. once I am sure publishing can work here.