### PR TITLE
chore: debug log to determine ip ranges

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,9 @@ const getMiddleware = () => (req, res, next) => {
 
   // Only expect private IPs from this range
   if (!blocklist.check(requestingIP)) {
+    // eslint-disable-next-line no-console
+    console.debug(`Blocking request from ${requestingIP}`);
+
     return next();
   }
 


### PR DESCRIPTION
issue: https://brandwatch.atlassian.net/browse/AS-454

Part of the 3.0.0-beta

Seems that some more IP ranges are needed to be added to the allow list. Hard to capture the requests so trying to log out to see if can get some additional info.