### PR TITLE
fix: pass ip version to blocklist check to ensure ipv6 accepted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,9 @@ const getMiddleware = () => (req, res, next) => {
                        || req.socket.remoteAddress || req.connection.socket.remoteAddress;
 
   // Only expect private IPs from this range
-  if (!blocklist.check(requestingIP)) {
+  const ipVersion = net.isIPv6(requestingIP) ? 'ipv6' : 'ipv4';
+
+  if (!blocklist.check(requestingIP, ipVersion)) {
     // eslint-disable-next-line no-console
     console.debug(`Blocking request from ${requestingIP}`);
 


### PR DESCRIPTION
Issue: https://brandwatch.atlassian.net/browse/AS-454

``` JS
> const blockList = new net.BlockList();
> blockList.addSubnet('10.0.0.0', 8);
> blockList.check('::ffff:10.220.73.9')
false
> blockList.check('::ffff:10.220.73.9', 'ipv6')
true
> blockList.check('::ffff:10.220.73.9', 'ipv4')
false
> net.isIPv6('::ffff:10.220.73.9');
true
> net.isIPv4('::ffff:10.220.73.9');
false
```